### PR TITLE
feat : mongo query log, 주문 주소 nullable, 주문번호 자동증가 

### DIFF
--- a/src/main/kotlin/org/inner/circle/o2oserver/order/application/OrderCommandFacade.kt
+++ b/src/main/kotlin/org/inner/circle/o2oserver/order/application/OrderCommandFacade.kt
@@ -21,7 +21,7 @@ class OrderCommandFacade(
         val member = memberUseCase.getMemberInfo(userName)
         val toOrder = OrderCreateRequest.OrderCreate.toOrder(orderCreate, member.memberId!!)
         val createOrder = orderUseCase.createOrder(toOrder)
-        log.info("review 생성 결과 : $createOrder")
+        log.info("order 생성 결과 : ${createOrder.orderId}")
         return OrderCreateResponse.OrderCreateResult.toResponse(createOrder)
     }
 

--- a/src/main/kotlin/org/inner/circle/o2oserver/order/infrastructure/repository/OrderEntity.kt
+++ b/src/main/kotlin/org/inner/circle/o2oserver/order/infrastructure/repository/OrderEntity.kt
@@ -131,9 +131,9 @@ class OrderEntity(
             )
         }
 
-        fun toEntity(order: Order): OrderEntity {
+        fun toEntity(order: Order, addLastOrderId: Long): OrderEntity {
             return OrderEntity(
-                orderId = order.orderId ?: 0,
+                orderId = addLastOrderId,
                 orderTime = order.orderTime ?: LocalDateTime.now(),
                 orderStatus = order.orderStatus ?: OrderStatus.PENDING,
                 orderPrice = order.orderPrice,

--- a/src/main/kotlin/org/inner/circle/o2oserver/order/infrastructure/repository/OrderRepository.kt
+++ b/src/main/kotlin/org/inner/circle/o2oserver/order/infrastructure/repository/OrderRepository.kt
@@ -2,11 +2,14 @@ package org.inner.circle.o2oserver.order.infrastructure.repository
 
 import org.bson.types.ObjectId
 import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.data.mongodb.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
 interface OrderRepository : MongoRepository<OrderEntity, ObjectId> {
-    fun findByOrderId(orderId: Long): OrderEntity?
+    fun findFirstByOrderByOrderId(orderId: Long): OrderEntity?
 
     fun findByMemberId(memberId: Long): List<OrderEntity>?
+
+    fun findFirstByOrderByOrderIdDesc(): OrderEntity?
 }

--- a/src/main/kotlin/org/inner/circle/o2oserver/order/infrastructure/repository/OrderStorage.kt
+++ b/src/main/kotlin/org/inner/circle/o2oserver/order/infrastructure/repository/OrderStorage.kt
@@ -28,7 +28,9 @@ class OrderStorage(
     }
 
     override fun saveOrder(order: Order): Order {
-        val orderEntity = OrderEntity.toEntity(order)
+        val lastOrder = orderRepository.findFirstByOrderByOrderIdDesc()
+        val addLastOrderId = lastOrder?.orderId?.plus(1) ?: 1
+        val orderEntity = OrderEntity.toEntity(order, addLastOrderId)
         // Todo : store 엔티티에서 주소가져와서 넣기
         val savedOrderEntity = orderRepository.save(orderEntity)
         return OrderEntity.toDomain(savedOrderEntity)
@@ -48,7 +50,7 @@ class OrderStorage(
     }
 
     private fun findByOrderId(orderId: Long): OrderEntity {
-        return orderRepository.findByOrderId(orderId)
+        return orderRepository.findFirstByOrderByOrderId(orderId)
             ?: throw Exceptions.BadRequestException(ErrorDetails.ORDER_NOT_FOUND.message)
     }
 }

--- a/src/main/kotlin/org/inner/circle/o2oserver/order/presentation/dto/OrderDetailResponse.kt
+++ b/src/main/kotlin/org/inner/circle/o2oserver/order/presentation/dto/OrderDetailResponse.kt
@@ -32,14 +32,14 @@ class OrderDetailResponse {
     data class StoreInfo(
         private val storeId: Long,
         private val storeName: String,
-        private val storeAddress: AddressInfo,
+        private val storeAddress: AddressInfo?,
     ) {
         companion object {
             fun toResponse(store: Order.Store): StoreInfo {
                 return StoreInfo(
                     storeId = store.storeId!!,
                     storeName = store.storeName,
-                    storeAddress = AddressInfo.toResponse(store.storeAddress!!),
+                    storeAddress = AddressInfo.toResponse(store.storeAddress),
                 )
             }
         }
@@ -54,14 +54,14 @@ class OrderDetailResponse {
         private val zipCode: String,
     ) {
         companion object {
-            fun toResponse(address: Order.Address): AddressInfo {
+            fun toResponse(address: Order.Address?): AddressInfo {
                 return AddressInfo(
-                    addressId = address.addressId,
-                    latitude = address.latitude.toString(),
-                    longitude = address.longitude.toString(),
-                    address = address.address,
-                    addressDetail = address.addressDetail,
-                    zipCode = address.zipCode,
+                    addressId = address?.addressId ?: 0,
+                    latitude = address?.latitude.toString(),
+                    longitude = address?.longitude.toString(),
+                    address = address?.address ?: "",
+                    addressDetail = address?.addressDetail ?: "",
+                    zipCode = address?.zipCode ?: "",
                 )
             }
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,6 +36,10 @@ logging:
     org:
       springframework:
         security: debug
+        data:
+          mongodb:
+            core:
+              MongoTemplate: debug
 
 jwt:
   key: veryLongSecretKeyThatIsMoreThan32BytesLongAndIsSecureEnough


### PR DESCRIPTION

## ✨ Summary

-  mongodb query log 추가,
- 주문 조회 시 주소 nullable
- 주문 생성 시 주문번호 임시로 자동증가되도록 추가 

## ✍🏻 Describe changes

-  mongodb query log 추가,
- 주문 조회 시 주소 nullable
- 주문 생성 시 주문번호 임시로 자동증가되도록 추가 

## 📌 Issue number

resolved: #
